### PR TITLE
Change sample.env and generate install link in terminal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,23 @@
+# Shopify API KEY and SECRET
 SHOPIFY_API_KEY=
 SHOPIFY_API_SECRET=
+# A list of access scopes can be found [here] 
+# https://shopify.dev/api/usage/access-scopes
 SHOPIFY_API_SCOPES=
-SHOPIFY_APP_URL=https://ngrok-url.io # Ensure it starts with `https://`
-SHOPIFY_API_VERSION="2023-01" # When deploying to Vercel, don't wrap in ""
+# For creating the installation link
+SHOPIFY_DEV_STORE_URL=yourshop.myshopify.com
+# Ensure it starts with https://
+SHOPIFY_APP_URL=https://ngrok-url.io
+# When deploying to Vercel, don't wrap in "" 
+SHOPIFY_API_VERSION="2023-01" 
+## DATABASE URL (POSTGRES)
 DATABASE_URL="postgresql://username:password@127.0.0.1:5432/shopify-app?schema=public"
-ENCRYPTION_STRING= #Required
+
+## For SQLite
+#DATABASE_URL=file:./dev.db
+
+# Change this value
+ENCRYPTION_STRING=12345 
 
 # To quickly install the app on your store, use this URL:
 # https://ngrok-url.io/api/auth?shop=storename.myshopify.com

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,13 @@ setupCheck();
 
 console.log(`--> Running in ${process.env.NODE_ENV} mode`);
 
+if (process.env.NODE_ENV === "development" ){
+    console.log("Use this link to access and install your app in your store: ");
+    console.log("================================================");
+    console.log(`${process.env.SHOPIFY_APP_URL}/api/auth?shop=${process.env.SHOPIFY_DEV_STORE_URL}`);
+    console.log("================================================");
+  }
+
 const nextConfig = {
   reactStrictMode: true,
   env: {


### PR DESCRIPTION
Hi, 

I made some changes to the sample.env and edited next.config.js, so the install link for the dev store (see .env) is generated and shown in terminal, if server is started in dev mode