### PR TITLE
Fix TypeError when throwing by using standard Error

### DIFF
--- a/_developer/updateDashboard.js
+++ b/_developer/updateDashboard.js
@@ -112,7 +112,7 @@ const updateDashboardURLs = async (apiKey, appUrl) => {
       .map((error) => error.message)
       .join(", ");
 
-    throw new errors.Abort(errors);
+    throw new Error(errors);
   }
 };
 


### PR DESCRIPTION
throw new errors.Abort(errors);
          ^
TypeError: errors.Abort is not a constructor.

Before this change, attempting to throw a custom `Abort` error resulted in a TypeError because `Abort` was not a constructor. This commit fixes the issue by throwing a standard Error with the user error messages, ensuring that the actual error message is displayed correctly.